### PR TITLE
Datasource selected column will not disappear now

### DIFF
--- a/dist/interface.js
+++ b/dist/interface.js
@@ -383,7 +383,7 @@
 	      }
 	
 	      this.onSelectChange();
-	      if (oldValue) {
+	      if (oldValue && dataSource.id !== oldValue.id) {
 	        // Reset selected columns and filters if switching from a non-null value
 	        this.selectedColumns = {};
 	        this.filters = [];

--- a/js/src/interface.js
+++ b/js/src/interface.js
@@ -250,7 +250,7 @@ let app = new Vue({
       }
       
       this.onSelectChange();
-      if (oldValue) {
+      if (oldValue && dataSource.id !== oldValue.id) {
         // Reset selected columns and filters if switching from a non-null value
         this.selectedColumns = {};
         this.filters = [];


### PR DESCRIPTION
Datasource columns (email for email verification and email and phone number for sms verification) were disappearing when you click on "edit data source" and then just close the modal, or just select the same datasource from the dropdown.
Ref. https://github.com/Fliplet/fliplet-studio/issues/3418#issuecomment-456043189