### PR TITLE
The "Select a data source" dropdown is empty

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -12,7 +12,7 @@
           <label class="select-proxy-display">
             <select data-label="select" class="hidden-select form-control" v-model="selectedDataSource"
                     :disabled="!dataSources">
-              <option value="none">-- \{{ dataSources ? 'Select a data source' : 'Please wait' }}</option>
+              <option value="none" selected>-- \{{ dataSources ? 'Select a data source' : 'Please wait' }}</option>
               <option disabled>------</option>
               <option value="new">Create a new data source</option>
               <option disabled>------</option>


### PR DESCRIPTION
@squallstar @tonytlwu 

Fixed behavior:
Added selected attribute to "--Select a data source" option in the dropdown.

ref https://github.com/Fliplet/fliplet-studio/issues/4784

![selected demo](https://user-images.githubusercontent.com/52824207/62524267-fa197900-b83d-11e9-98bc-55e4f8739bf4.gif)
