### PR TITLE
When user cancels data source creation dropdown switches back to default placeholder

### DIFF
--- a/dist/interface.js
+++ b/dist/interface.js
@@ -383,7 +383,7 @@
 	      }
 	
 	      this.onSelectChange();
-	      if (oldValue && dataSource.id !== oldValue.id) {
+	      if (oldValue && dataSource && dataSource.id !== oldValue.id) {
 	        // Reset selected columns and filters if switching from a non-null value
 	        this.selectedColumns = {};
 	        this.filters = [];
@@ -489,6 +489,7 @@
 	        title: 'Please type a name for your data source'
 	      }).then(function (result) {
 	        if (result === null) {
+	          _this4.selectedDataSource = null;
 	          return;
 	        }
 	

--- a/js/src/interface.js
+++ b/js/src/interface.js
@@ -250,7 +250,7 @@ let app = new Vue({
       }
 
       this.onSelectChange();
-      if (oldValue && dataSource.id !== oldValue.id) {
+      if (oldValue && dataSource && dataSource.id !== oldValue.id) {
         // Reset selected columns and filters if switching from a non-null value
         this.selectedColumns = {};
         this.filters = [];
@@ -349,6 +349,7 @@ let app = new Vue({
         title: 'Please type a name for your data source',
       }).then(result => {
         if (result === null) {
+          this.selectedDataSource = null;
           return;
         }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5848

## Description
If the user cancels data source creation dropdown switches back to default placeholder.

## Screenshots/screencasts
![ds-cancel](https://user-images.githubusercontent.com/52824207/77625501-5e638700-6f4c-11ea-8a8a-e57804710533.gif)

## Backward compatibility
This change is fully backward compatible.