### PR TITLE
Edit data source button now disappears when user switches back to placeholder

### DIFF
--- a/dist/interface.js
+++ b/dist/interface.js
@@ -377,7 +377,7 @@
 	      this.onSelectChange();
 	    },
 	    selectedDataSource: function selectedDataSource(dataSource, oldValue) {
-	      this.manageDataBtn = dataSource && dataSource !== null && dataSource !== 'new';
+	      this.manageDataBtn = dataSource && dataSource !== 'null' && dataSource !== 'new';
 	      if (dataSource === 'new') {
 	        this.createDataSource();
 	      }

--- a/js/src/interface.js
+++ b/js/src/interface.js
@@ -244,7 +244,7 @@ let app = new Vue({
       this.onSelectChange();
     },
     selectedDataSource(dataSource, oldValue) {
-      this.manageDataBtn = dataSource && dataSource !== null && dataSource !== 'new';
+      this.manageDataBtn = dataSource && dataSource !== 'null' && dataSource !== 'new';
       if (dataSource === 'new') {
         this.createDataSource();
       }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5662

## Description
I found that this issue reproduces also for email and SMS verification components.
When the user switches back to 'Select a data source' placeholder value it passes to the data source query is null as a string.
![ds-query](https://user-images.githubusercontent.com/52824207/78786294-3561de00-79b1-11ea-8a4f-991360997d36.PNG)

## Screenshots/screencasts
https://streamable.com/0yvrpz

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii

## Backward compatibility

This change is fully backward compatible.